### PR TITLE
RA-39 add categories caching

### DIFF
--- a/app/src/main/java/com/ifedorov/recipesapp/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/local/AppDatabase.kt
@@ -1,0 +1,11 @@
+package com.ifedorov.recipesapp.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.ifedorov.recipesapp.data.local.dao.CategoriesDao
+import com.ifedorov.recipesapp.model.Category
+
+@Database(entities = [Category::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun categoriesDao(): CategoriesDao
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/CategoriesDao.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/CategoriesDao.kt
@@ -1,0 +1,16 @@
+package com.ifedorov.recipesapp.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.ifedorov.recipesapp.model.Category
+
+@Dao
+interface CategoriesDao {
+    @Query("SELECT * FROM categories")
+    suspend fun getCategories(): List<Category>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCategories(categories: List<Category>)
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/model/Category.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/model/Category.kt
@@ -1,14 +1,18 @@
 package com.ifedorov.recipesapp.model
 
 import android.os.Parcelable
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
 @Parcelize
 @Serializable
+@Entity(tableName = "categories")
 data class Category(
-    val id: Int,
+    @PrimaryKey val id: Int,
     val title: String,
     val description: String,
-    val imageUrl: String,
+    @ColumnInfo(name = "image_url") val imageUrl: String,
 ) : Parcelable

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListViewModel.kt
@@ -29,11 +29,9 @@ class CategoriesListViewModel(application: Application) : AndroidViewModel(appli
             try {
                 val cachedCategories = repository.getCategoriesFromCache()
 
-                if (cachedCategories.isNotEmpty()) {
-                    _state.value = _state.value?.copy(
-                        categoriesList = cachedCategories
-                    )
-                }
+                 _state.value = _state.value?.copy(
+                    categoriesList = cachedCategories
+                )
 
                 val categories = repository.getCategories()
                 repository.saveCategoriesToCache(categories)

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -18,8 +18,8 @@ data class FavoritesState(
 )
 
 class FavoritesViewModel(application: Application) : AndroidViewModel(application) {
-    private val repository = RecipesRepository()
     private val appContext: Context = application.applicationContext
+    private val repository = RecipesRepository(appContext)
 
     private val _state = MutableLiveData<FavoritesState>()
         .apply { value = FavoritesState() }

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -21,8 +21,8 @@ data class RecipeUiState(
 )
 
 class RecipeViewModel(application: Application) : AndroidViewModel(application) {
-    private val repository = RecipesRepository()
     private val appContext: Context = application.applicationContext
+    private val repository = RecipesRepository(appContext)
 
     private val _state = MutableLiveData<RecipeUiState>().apply { value = RecipeUiState() }
     val state: LiveData<RecipeUiState> get() = _state

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListViewModel.kt
@@ -19,7 +19,8 @@ data class RecipesListUiState(
 )
 
 class RecipesListViewModel(application: Application) : AndroidViewModel(application) {
-    private val repository = RecipesRepository()
+    private val appContext = application.applicationContext
+    private val repository = RecipesRepository(appContext)
 
     private val _state = MutableLiveData<RecipesListUiState>()
         .apply { value = RecipesListUiState() }


### PR DESCRIPTION
Как обычно остались вопросы:
1. Нужно ли разделять сущности для Room и Api ? Сейчас используется один и тот же класс.
2. Для создания экземпляра БД в репозитории пришлось передавать контекст в `RecipesRepository` . Я так понимаю, в продакшене так не делается ? То же самое про передачу `application` во `ViewModel`. То есть правильно было бы передавать в конструктор репозитория api и db, а в конструктор viewModel - репозиторий?
3. Так же видел вариант с созданием db на уровне application и создание фабрики VM для передачи репозитория. Он еще актуален?
4. Сейчас в  `CategoriesListViewModel` сперва запрашиваю кэшированные данные с db -> обновляю state. Потом снова запрашиваю данные с api -> снова обновляю state. Нужно ли как-то сравнивать эти два списка категорий (с db и с api), чтобы лишний раз не обновлять state?