### PR TITLE
RA-41 favorites caching

### DIFF
--- a/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/RecipesDao.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/RecipesDao.kt
@@ -13,4 +13,10 @@ interface RecipesDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRecipes(recipes: List<Recipe>)
+
+    @Query("SELECT * FROM recipes WHERE id = :recipeId")
+    suspend fun getRecipeById(recipeId: Int): Recipe?
+
+    @Query("SELECT * FROM recipes WHERE is_favorite = true")
+    suspend fun getFavorites(): List<Recipe>
 }

--- a/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/RecipesDao.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/local/dao/RecipesDao.kt
@@ -17,6 +17,6 @@ interface RecipesDao {
     @Query("SELECT * FROM recipes WHERE id = :recipeId")
     suspend fun getRecipeById(recipeId: Int): Recipe?
 
-    @Query("SELECT * FROM recipes WHERE is_favorite = true")
+    @Query("SELECT * FROM recipes WHERE is_favorite = 1")
     suspend fun getFavorites(): List<Recipe>
 }

--- a/app/src/main/java/com/ifedorov/recipesapp/data/repository/RecipesRepository.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/repository/RecipesRepository.kt
@@ -84,6 +84,12 @@ class RecipesRepository(context: Context) {
         recipesDao.insertRecipes(recipes)
     }
 
+    suspend fun getRecipeByIdFromCache(recipeId: Int): Recipe? =
+        recipesDao.getRecipeById(recipeId)
+
+    suspend fun getFavoritesFromCache(): List<Recipe> =
+        recipesDao.getFavorites()
+
     companion object {
         private const val BASE_URL = "https://recipes.androidsprint.ru/api/"
     }

--- a/app/src/main/java/com/ifedorov/recipesapp/model/Recipe.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/model/Recipe.kt
@@ -17,4 +17,5 @@ data class Recipe(
     val method: List<String>,
     @ColumnInfo(name = "image_url") val imageUrl: String,
     @ColumnInfo(name = "category_id") val categoryId: Int = 0,
+    @ColumnInfo(name = "is_favorite") val isFavorite: Boolean = false,
 ) : Parcelable

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -33,7 +33,17 @@ class FavoritesViewModel(application: Application) : AndroidViewModel(applicatio
 
         viewModelScope.launch {
             try {
+                val cachedFavorites = repository.getFavoritesFromCache()
+
+                _state.value = _state.value?.copy(
+                    favoritesRecipes = cachedFavorites,
+                    error = null
+                )
+
                 val recipes = repository.getRecipesByIds(favoritesIds)
+                    .map { it.copy(isFavorite = true) }
+
+                repository.saveRecipesToCache(recipes)
 
                 _state.value = _state.value?.copy(
                     favoritesRecipes = recipes,

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.ifedorov.recipesapp.R
 import com.ifedorov.recipesapp.data.repository.RecipesRepository
 import com.ifedorov.recipesapp.model.Recipe
 import kotlinx.coroutines.launch
@@ -28,25 +27,12 @@ class FavoritesViewModel(application: Application) : AndroidViewModel(applicatio
     fun loadFavoritesRecipes() {
         _state.value = _state.value?.copy(error = null, isLoading = true)
 
-        val favoritesStringSet = getFavorites()
-        val favoritesIds: Set<Int> = favoritesStringSet.mapNotNull { it.toIntOrNull() }.toSet()
-
         viewModelScope.launch {
             try {
                 val cachedFavorites = repository.getFavoritesFromCache()
 
                 _state.value = _state.value?.copy(
                     favoritesRecipes = cachedFavorites,
-                    error = null
-                )
-
-                val recipes = repository.getRecipesByIds(favoritesIds)
-                    .map { it.copy(isFavorite = true) }
-
-                repository.saveRecipesToCache(recipes)
-
-                _state.value = _state.value?.copy(
-                    favoritesRecipes = recipes,
                     error = null,
                     isLoading = false
                 )
@@ -57,18 +43,5 @@ class FavoritesViewModel(application: Application) : AndroidViewModel(applicatio
                 )
             }
         }
-    }
-
-    private fun getFavorites(): MutableSet<String> {
-        val sharedPrefs = appContext.getSharedPreferences(
-            appContext.getString(R.string.preference_favorites_recipes),
-            Context.MODE_PRIVATE
-        )
-        val savedSet = sharedPrefs.getStringSet(
-            appContext.getString(R.string.saved_favorites_recipes),
-            emptySet()
-        )
-
-        return HashSet(savedSet)
     }
 }

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeFragment.kt
@@ -96,7 +96,9 @@ class RecipeFragment : Fragment() {
                 ingredientsAdapter.updateIngredients(state.servings)
             }
 
-            updateFavoriteIcon(state.isFavorite)
+            state.recipe?.let { recipe ->
+                updateFavoriteIcon(recipe.isFavorite)
+            }
 
             if (state.error != null) {
                 Toast.makeText(requireContext(), state.error, Toast.LENGTH_LONG).show()


### PR DESCRIPTION
Иван, добрый.
Так же добавил для экрана с рецептом загрузку данных из кеша.  Из стейта `RecipeUiState` удалил повторяющийся `isFavorite` (т.к свойство теперь в самом рецепте).
Осталось внести небольшой фикс. Если отключить интернет и добавить рецепт в избранное, то на экране "Favorites" рецепт не отображается, так как методе `onFavoritesClicked()` я не записываю флаг рецепта "isFavorite" в бд. И если снова включить интернет, то может возникнуть вот такой рассинхрон между sharedPref и бд как в этом видео(https://disk.yandex.ru/i/FAsoZQVxi_c4kg). 
Вопросы:
1. Чтобы это починить, мне нужно в методе `onFavoritesClicked()` прописать `repository.saveRecipesToCache(listOf(it))`. Но я могу вызвать его только из suspend функции или корутины. Как будет правильно: сделать функцию fun onFavoritesClicked() suspend и в фрагменте в `setOnClickListener` все обернуть в scope (только в какой scope?) или не делать ее suspend а только вызвать `repository.saveRecipesToCache(listOf(it))` в корутине и во фрагменте ничего не нужно будет менять?
2. Я так понимаю, что если бд пуста, то в методах получения списков (рецептов или категорий) из бд вернется пустой список. Но если возвращаешь рецепт и в это же время бд будет пуста, то room выбросит исключение? Поэтому лучше делать возвращаемый nullable ?
3.  Касательно запроса
```kotlin
    @Query("SELECT * FROM recipes WHERE is_favorite = true")
    suspend fun getFavorites(): List<Recipe>
```
Среда разработки подчеркивает true: `Boolean literals require API level 30 (current min is 28). `
Как правильнее, условие с `true` или `1` ? Понимаю, что room сам преобразовывает true в 1 в бд.
4. Сейчас у меня favorites берется и с sharedPref и с бд и приходится их правильно синхронизировать. Я так понимаю, что room будет предпочтительнее в текущем приложении и от shredPref нужно избавляться?