### PR TITLE
RA-44 implement manual dependency injection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name="com.ifedorov.RecipeApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/ifedorov/RecipeApplication.kt
+++ b/app/src/main/java/com/ifedorov/RecipeApplication.kt
@@ -1,0 +1,14 @@
+package com.ifedorov
+
+import android.app.Application
+import com.ifedorov.recipesapp.di.AppContainer
+
+class RecipeApplication : Application() {
+    lateinit var appContainer: AppContainer
+
+    override fun onCreate() {
+        super.onCreate()
+
+        appContainer = AppContainer(this)
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/data/repository/RecipesRepository.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/data/repository/RecipesRepository.kt
@@ -1,73 +1,31 @@
 package com.ifedorov.recipesapp.data.repository
 
-import android.content.Context
-import androidx.room.Room
 import com.ifedorov.recipesapp.data.api.RecipeApiService
-import com.ifedorov.recipesapp.data.local.AppDatabase
+import com.ifedorov.recipesapp.data.local.dao.CategoriesDao
+import com.ifedorov.recipesapp.data.local.dao.RecipesDao
 import com.ifedorov.recipesapp.model.Category
 import com.ifedorov.recipesapp.model.Recipe
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
-import retrofit2.Retrofit
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
-class RecipesRepository(context: Context) {
-    private val json = Json { ignoreUnknownKeys = true }
-    private val logging = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.BODY
-    }
-    private val client: OkHttpClient = OkHttpClient.Builder()
-        .addInterceptor(logging)
-        .build()
-
-    private val retrofit: Retrofit = Retrofit.Builder()
-        .baseUrl(BASE_URL)
-        .client(client)
-        .addConverterFactory(
-            json.asConverterFactory(
-                "application/json; charset=utf-8".toMediaType()
-            )
-        )
-        .build()
-
-    private val service: RecipeApiService = retrofit.create(RecipeApiService::class.java)
-
-    private val db: AppDatabase = Room.databaseBuilder(
-        context,
-        AppDatabase::class.java,
-        "database-recipes"
-    ).build()
-
-    private val categoriesDao = db.categoriesDao()
-    private val recipesDao = db.recipesDao()
-
+class RecipesRepository(
+    private val categoriesDao: CategoriesDao,
+    private val recipesDao: RecipesDao,
+    private val service: RecipeApiService
+) {
     suspend fun getCategories(): List<Category> =
-        withContext(Dispatchers.IO) {
-            service.getCategories()
-        }
+        service.getCategories()
 
     suspend fun getRecipesByCategoryId(categoryId: Int): List<Recipe> =
-        withContext(Dispatchers.IO) {
-            service.getRecipesByCategoryId(categoryId)
-        }
+        service.getRecipesByCategoryId(categoryId)
 
     suspend fun getRecipeById(recipeId: Int): Recipe =
-        withContext(Dispatchers.IO) {
-            service.getRecipeById(recipeId)
-        }
+        service.getRecipeById(recipeId)
 
     suspend fun getRecipesByIds(recipesIds: Set<Int>): List<Recipe> =
-        withContext(Dispatchers.IO) {
-            if (recipesIds.isEmpty()) {
-                emptyList()
-            } else {
-                val idsString = recipesIds.joinToString(separator = ",")
-                service.getRecipesByIds(idsString)
-            }
+        if (recipesIds.isEmpty()) {
+            emptyList()
+        } else {
+            val idsString = recipesIds.joinToString(separator = ",")
+            service.getRecipesByIds(idsString)
         }
 
     suspend fun getCategoriesFromCache(): List<Category> =
@@ -89,8 +47,4 @@ class RecipesRepository(context: Context) {
 
     suspend fun getFavoritesFromCache(): List<Recipe> =
         recipesDao.getFavorites()
-
-    companion object {
-        private const val BASE_URL = "https://recipes.androidsprint.ru/api/"
-    }
 }

--- a/app/src/main/java/com/ifedorov/recipesapp/di/AppContainer.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/AppContainer.kt
@@ -1,0 +1,60 @@
+package com.ifedorov.recipesapp.di
+
+import android.content.Context
+import androidx.room.Room
+import com.ifedorov.recipesapp.data.api.RecipeApiService
+import com.ifedorov.recipesapp.data.local.AppDatabase
+import com.ifedorov.recipesapp.data.repository.RecipesRepository
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+class AppContainer(context: Context) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val logging = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    private val client: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(logging)
+        .build()
+
+    private val retrofit: Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(
+            json.asConverterFactory(
+                "application/json; charset=utf-8".toMediaType()
+            )
+        )
+        .build()
+
+    private val recipeApiService: RecipeApiService = retrofit.create(RecipeApiService::class.java)
+
+    private val db: AppDatabase = Room.databaseBuilder(
+        context,
+        AppDatabase::class.java,
+        "database-recipes"
+    ).build()
+
+    private val categoriesDao = db.categoriesDao()
+    private val recipesDao = db.recipesDao()
+
+    val repository = RecipesRepository(
+        categoriesDao = categoriesDao,
+        recipesDao = recipesDao,
+        service = recipeApiService
+    )
+
+    val categoriesListViewModelFactory = CategoriesListViewModelFactory(repository)
+    val recipesListViewModelFactory = RecipesListViewModelFactory(repository)
+    val favoritesViewModelFactory = FavoritesViewModelFactory(repository)
+    val recipeViewModelFactory = RecipeViewModelFactory(repository)
+
+    companion object {
+        private const val BASE_URL = "https://recipes.androidsprint.ru/api/"
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/di/CategiriesListViewModelFactory.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/CategiriesListViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.ifedorov.recipesapp.di
+
+import com.ifedorov.recipesapp.data.repository.RecipesRepository
+import com.ifedorov.recipesapp.ui.categories.CategoriesListViewModel
+
+class CategoriesListViewModelFactory(
+    private val recipesRepository: RecipesRepository
+) : Factory<CategoriesListViewModel> {
+
+    override fun create(): CategoriesListViewModel {
+        return CategoriesListViewModel(recipesRepository)
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/di/Factory.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/Factory.kt
@@ -1,0 +1,5 @@
+package com.ifedorov.recipesapp.di
+
+interface Factory<T> {
+    fun create(): T
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/di/FavoritesViewModelFactory.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/FavoritesViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.ifedorov.recipesapp.di
+
+import com.ifedorov.recipesapp.data.repository.RecipesRepository
+import com.ifedorov.recipesapp.ui.recipes.favorites.FavoritesViewModel
+
+class FavoritesViewModelFactory(
+    private val recipesRepository: RecipesRepository
+) : Factory<FavoritesViewModel> {
+
+    override fun create(): FavoritesViewModel {
+        return FavoritesViewModel(recipesRepository)
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/di/RecipeViewModelFactory.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/RecipeViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.ifedorov.recipesapp.di
+
+import com.ifedorov.recipesapp.data.repository.RecipesRepository
+import com.ifedorov.recipesapp.ui.recipes.recipe.RecipeViewModel
+
+class RecipeViewModelFactory(
+    private val recipesRepository: RecipesRepository
+) : Factory<RecipeViewModel> {
+
+    override fun create(): RecipeViewModel {
+        return RecipeViewModel(recipesRepository)
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/di/RecipesListViewModelFactory.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/di/RecipesListViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.ifedorov.recipesapp.di
+
+import com.ifedorov.recipesapp.data.repository.RecipesRepository
+import com.ifedorov.recipesapp.ui.recipes.recipesList.RecipesListViewModel
+
+class RecipesListViewModelFactory(
+    private val recipesRepository: RecipesRepository
+) : Factory<RecipesListViewModel> {
+
+    override fun create(): RecipesListViewModel {
+        return RecipesListViewModel(recipesRepository)
+    }
+}

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListFragment.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListFragment.kt
@@ -6,8 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.ifedorov.RecipeApplication
 import com.ifedorov.recipesapp.databinding.FragmentListCategoriesBinding
 
 class CategoriesListFragment : Fragment() {
@@ -16,8 +16,15 @@ class CategoriesListFragment : Fragment() {
         get() = _binding
             ?: throw IllegalStateException("FragmentListCategoriesBinding can't be null")
 
-    private val viewModel: CategoriesListViewModel by viewModels()
+    private lateinit var viewModel: CategoriesListViewModel
     private var categoriesListAdapter = CategoriesListAdapter(emptyList())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val appContainer = (requireActivity().application as RecipeApplication).appContainer
+        viewModel = appContainer.categoriesListViewModelFactory.create()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/categories/CategoriesListViewModel.kt
@@ -1,9 +1,8 @@
 package com.ifedorov.recipesapp.ui.categories
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ifedorov.recipesapp.data.repository.RecipesRepository
 import com.ifedorov.recipesapp.model.Category
@@ -15,9 +14,8 @@ data class CategoriesListState(
     val error: String? = null,
 )
 
-class CategoriesListViewModel(application: Application) : AndroidViewModel(application) {
-    private val appContext = application.applicationContext
-    private val repository = RecipesRepository(appContext)
+class CategoriesListViewModel(private val repository: RecipesRepository) : ViewModel() {
+
     private val _state = MutableLiveData<CategoriesListState>()
         .apply { value = CategoriesListState() }
     val state: LiveData<CategoriesListState> get() = _state
@@ -29,7 +27,7 @@ class CategoriesListViewModel(application: Application) : AndroidViewModel(appli
             try {
                 val cachedCategories = repository.getCategoriesFromCache()
 
-                 _state.value = _state.value?.copy(
+                _state.value = _state.value?.copy(
                     categoriesList = cachedCategories
                 )
 

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesFragment.kt
@@ -7,8 +7,8 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import com.ifedorov.RecipeApplication
 import com.ifedorov.recipesapp.databinding.FragmentFavoritesBinding
 import com.ifedorov.recipesapp.ui.recipes.recipesList.RecipesListAdapter
 
@@ -17,8 +17,15 @@ class FavoritesFragment : Fragment() {
     private val binding
         get() = _binding ?: throw IllegalStateException("FragmentFavoritesBinding can't be null")
 
-    private val viewModel: FavoritesViewModel by viewModels()
+    private lateinit var viewModel: FavoritesViewModel
     private var favoritesAdapter = RecipesListAdapter(emptyList())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val appContainer = (requireActivity().application as RecipeApplication).appContainer
+        viewModel = appContainer.favoritesViewModelFactory.create()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -1,10 +1,8 @@
 package com.ifedorov.recipesapp.ui.recipes.favorites
 
-import android.app.Application
-import android.content.Context
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ifedorov.recipesapp.data.repository.RecipesRepository
 import com.ifedorov.recipesapp.model.Recipe
@@ -16,9 +14,7 @@ data class FavoritesState(
     val error: String? = null,
 )
 
-class FavoritesViewModel(application: Application) : AndroidViewModel(application) {
-    private val appContext: Context = application.applicationContext
-    private val repository = RecipesRepository(appContext)
+class FavoritesViewModel(private val repository: RecipesRepository) : ViewModel() {
 
     private val _state = MutableLiveData<FavoritesState>()
         .apply { value = FavoritesState() }

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeFragment.kt
@@ -8,10 +8,10 @@ import android.widget.SeekBar
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
 import com.google.android.material.divider.MaterialDividerItemDecoration
+import com.ifedorov.RecipeApplication
 import com.ifedorov.recipesapp.R
 import com.ifedorov.recipesapp.common.Constants.IMAGES_BASE_URL
 import com.ifedorov.recipesapp.databinding.FragmentRecipeBinding
@@ -21,10 +21,17 @@ class RecipeFragment : Fragment() {
     private val binding
         get() = _binding ?: throw IllegalStateException("FragmentRecipeBinding can't be null")
 
-    private val viewModel: RecipeViewModel by viewModels()
+    private lateinit var viewModel: RecipeViewModel
     private var ingredientsAdapter = IngredientsAdapter(emptyList())
     private var methodAdapter = MethodAdapter(emptyList())
     private val args: RecipeFragmentArgs by navArgs()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val appContainer = (requireActivity().application as RecipeApplication).appContainer
+        viewModel = appContainer.recipeViewModelFactory.create()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -1,10 +1,8 @@
 package com.ifedorov.recipesapp.ui.recipes.recipe
 
-import android.app.Application
-import android.content.Context
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ifedorov.recipesapp.data.repository.RecipesRepository
 import com.ifedorov.recipesapp.model.Recipe
@@ -18,10 +16,7 @@ data class RecipeUiState(
     val error: String? = null,
 )
 
-class RecipeViewModel(application: Application) : AndroidViewModel(application) {
-    private val appContext: Context = application.applicationContext
-    private val repository = RecipesRepository(appContext)
-
+class RecipeViewModel(private val repository: RecipesRepository) : ViewModel() {
     private val _state = MutableLiveData<RecipeUiState>().apply { value = RecipeUiState() }
     val state: LiveData<RecipeUiState> get() = _state
 

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListFragment.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListFragment.kt
@@ -6,10 +6,10 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.bumptech.glide.Glide
+import com.ifedorov.RecipeApplication
 import com.ifedorov.recipesapp.R
 import com.ifedorov.recipesapp.common.Constants.IMAGES_BASE_URL
 import com.ifedorov.recipesapp.databinding.FragmentRecipesListBinding
@@ -19,9 +19,16 @@ class RecipesListFragment : Fragment() {
     private val binding
         get() = _binding ?: throw IllegalStateException("FragmentRecipesListBinding can't be null")
 
-    private val viewModel: RecipesListViewModel by viewModels()
+    private lateinit var viewModel: RecipesListViewModel
     private var recipesListAdapter = RecipesListAdapter(emptyList())
     private val args: RecipesListFragmentArgs by navArgs()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val appContainer = (requireActivity().application as RecipeApplication).appContainer
+        viewModel = appContainer.recipesListViewModelFactory.create()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListViewModel.kt
+++ b/app/src/main/java/com/ifedorov/recipesapp/ui/recipes/recipesList/RecipesListViewModel.kt
@@ -1,9 +1,8 @@
 package com.ifedorov.recipesapp.ui.recipes.recipesList
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ifedorov.recipesapp.data.repository.RecipesRepository
 import com.ifedorov.recipesapp.model.Category
@@ -18,9 +17,7 @@ data class RecipesListUiState(
     val error: String? = null,
 )
 
-class RecipesListViewModel(application: Application) : AndroidViewModel(application) {
-    private val appContext = application.applicationContext
-    private val repository = RecipesRepository(appContext)
+class RecipesListViewModel(private val repository: RecipesRepository) : ViewModel() {
 
     private val _state = MutableLiveData<RecipesListUiState>()
         .apply { value = RecipesListUiState() }


### PR DESCRIPTION
Мне все еще не очень нравится, что во viewModels находится логика обработки данных с кеша и сети. Ты говорил, что в реальных проектах с использованием Flow, во viewModel просто подписываемся на эти изменения. Почему нельзя сделать то же самое с LiveData и observe? Почему google не рекомендует использовать LiveData в репозитории?
Я просто хочу сразу сделать все правильно в данном приложении, и если переносить эту логику в репозиторий, то как это будет выглядеть? Все таки это ошибка, или нет, оставлять эту логику во viewModels ?
  